### PR TITLE
feat: Add PubSub integration for real-time workflow updates

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -70,16 +70,17 @@ This document breaks down the MVP implementation into manageable tasks with clea
 
 ### Real-time Infrastructure (Depends on Core Processing)
 
-#### TASK-005: PubSub Integration
+#### TASK-005: PubSub Integration ✅ COMPLETED
 **Priority:** High | **Estimated Time:** 1-2 hours
-- [ ] Configure Phoenix PubSub in application.ex
-- [ ] Add PubSub broadcasting to webhook handler after database updates
-- [ ] Define message formats for workflow_run_updated and workflow_job_updated
-- [ ] Create helper module for PubSub topic management
-- [ ] Write tests for PubSub message broadcasting
+- [x] Configure Phoenix PubSub in application.ex
+- [x] Add PubSub broadcasting to webhook handler after database updates
+- [x] Define message formats for workflow_run_updated and workflow_job_updated
+- [x] Create helper module for PubSub topic management
+- [x] Write tests for PubSub message broadcasting
 
 **Dependencies:** TASK-004
 **Test Coverage:** Message broadcasting, topic subscription, message formats
+**Completed:** Phoenix PubSub integration with CiRunners.PubSub helper module, automated broadcasting from context modules (WorkflowRuns/WorkflowJobs), standardized message formats for workflow_run_updated and workflow_job_updated events, comprehensive test coverage (8 tests) including subscription/unsubscription and integration tests
 
 ### LiveView Implementation (Depends on Real-time Infrastructure)
 

--- a/lib/ci_runners/pubsub.ex
+++ b/lib/ci_runners/pubsub.ex
@@ -1,0 +1,103 @@
+defmodule CiRunners.PubSub do
+  @moduledoc """
+  PubSub helper module for broadcasting workflow events.
+
+  This module provides functions for broadcasting workflow run and job updates
+  to subscribers, enabling real-time dashboard updates.
+  """
+
+  alias Phoenix.PubSub
+
+  @pubsub_name CiRunners.PubSub
+
+  @doc """
+  Broadcasts a workflow run update to all subscribers.
+
+  ## Parameters
+  - workflow_run: The WorkflowRun struct that was updated
+  - status: The workflow status ("queued", "in_progress", "completed", etc.)
+
+  ## Examples
+      iex> CiRunners.PubSub.broadcast_workflow_run_update(workflow_run, "completed")
+      :ok
+  """
+  def broadcast_workflow_run_update(workflow_run, event_type) do
+    message = %{
+      type: :workflow_run_updated,
+      event_type: event_type,
+      workflow_run: workflow_run
+    }
+
+    PubSub.broadcast(@pubsub_name, workflow_runs_topic(), message)
+  end
+
+  @doc """
+  Broadcasts a workflow job update to all subscribers.
+
+  ## Parameters
+  - workflow_job: The WorkflowJob struct that was updated
+  - status: The workflow job status ("queued", "in_progress", "completed", etc.)
+
+  ## Examples
+      iex> CiRunners.PubSub.broadcast_workflow_job_update(workflow_job, "completed")
+      :ok
+  """
+  def broadcast_workflow_job_update(workflow_job, event_type) do
+    message = %{
+      type: :workflow_job_updated,
+      event_type: event_type,
+      workflow_job: workflow_job
+    }
+
+    PubSub.broadcast(@pubsub_name, workflow_jobs_topic(), message)
+  end
+
+  @doc """
+  Subscribes to workflow run updates.
+
+  ## Examples
+      iex> CiRunners.PubSub.subscribe_to_workflow_runs()
+      :ok
+  """
+  def subscribe_to_workflow_runs do
+    PubSub.subscribe(@pubsub_name, workflow_runs_topic())
+  end
+
+  @doc """
+  Subscribes to workflow job updates.
+
+  ## Examples
+      iex> CiRunners.PubSub.subscribe_to_workflow_jobs()
+      :ok
+  """
+  def subscribe_to_workflow_jobs do
+    PubSub.subscribe(@pubsub_name, workflow_jobs_topic())
+  end
+
+  @doc """
+  Unsubscribes from workflow run updates.
+
+  ## Examples
+      iex> CiRunners.PubSub.unsubscribe_from_workflow_runs()
+      :ok
+  """
+  def unsubscribe_from_workflow_runs do
+    PubSub.unsubscribe(@pubsub_name, workflow_runs_topic())
+  end
+
+  @doc """
+  Unsubscribes from workflow job updates.
+
+  ## Examples
+      iex> CiRunners.PubSub.unsubscribe_from_workflow_jobs()
+      :ok
+  """
+  def unsubscribe_from_workflow_jobs do
+    PubSub.unsubscribe(@pubsub_name, workflow_jobs_topic())
+  end
+
+  # Private functions
+
+  defp workflow_runs_topic, do: "workflow_runs"
+  defp workflow_jobs_topic, do: "workflow_jobs"
+end

--- a/test/ci_runners/pubsub_test.exs
+++ b/test/ci_runners/pubsub_test.exs
@@ -1,0 +1,348 @@
+defmodule CiRunners.PubSubTest do
+  use CiRunners.DataCase, async: true
+
+  alias CiRunners.PubSub
+  alias CiRunners.Github.{Repository, WorkflowRun, WorkflowJob}
+  alias CiRunners.Repo
+
+  describe "workflow run broadcasting" do
+    test "broadcast_workflow_run_update/2 broadcasts correct message format" do
+      repository =
+        %Repository{}
+        |> Repository.changeset(%{
+          github_id: 123_456,
+          owner: "test",
+          name: "repo"
+        })
+        |> Repo.insert!()
+
+      workflow_run =
+        %WorkflowRun{}
+        |> WorkflowRun.changeset(%{
+          github_id: 1_234_567_890,
+          name: "CI",
+          status: "completed",
+          workflow_id: 161_335,
+          head_branch: "main",
+          head_sha: "abc123",
+          run_number: 42,
+          started_at: ~U[2021-01-01 00:00:00Z],
+          repository_id: repository.id
+        })
+        |> Repo.insert!()
+
+      # Subscribe to workflow runs
+      assert :ok = PubSub.subscribe_to_workflow_runs()
+
+      # Broadcast update
+      assert :ok = PubSub.broadcast_workflow_run_update(workflow_run, "completed")
+
+      # Verify message received
+      assert_receive %{
+        type: :workflow_run_updated,
+        event_type: "completed",
+        workflow_run: ^workflow_run
+      }
+    end
+
+    test "subscribe_to_workflow_runs/0 allows receiving messages" do
+      repository =
+        %Repository{}
+        |> Repository.changeset(%{
+          github_id: 123_456,
+          owner: "test",
+          name: "repo"
+        })
+        |> Repo.insert!()
+
+      workflow_run =
+        %WorkflowRun{}
+        |> WorkflowRun.changeset(%{
+          github_id: 1_234_567_890,
+          name: "CI",
+          status: "in_progress",
+          workflow_id: 161_335,
+          head_branch: "main",
+          head_sha: "abc123",
+          run_number: 42,
+          started_at: ~U[2021-01-01 00:00:00Z],
+          repository_id: repository.id
+        })
+        |> Repo.insert!()
+
+      # Subscribe and broadcast
+      assert :ok = PubSub.subscribe_to_workflow_runs()
+      assert :ok = PubSub.broadcast_workflow_run_update(workflow_run, "in_progress")
+
+      # Should receive message
+      assert_receive %{type: :workflow_run_updated, event_type: "in_progress"}
+    end
+
+    test "unsubscribe_from_workflow_runs/0 stops receiving messages" do
+      repository =
+        %Repository{}
+        |> Repository.changeset(%{
+          github_id: 123_456,
+          owner: "test",
+          name: "repo"
+        })
+        |> Repo.insert!()
+
+      workflow_run =
+        %WorkflowRun{}
+        |> WorkflowRun.changeset(%{
+          github_id: 1_234_567_890,
+          name: "CI",
+          status: "completed",
+          workflow_id: 161_335,
+          head_branch: "main",
+          head_sha: "abc123",
+          run_number: 42,
+          started_at: ~U[2021-01-01 00:00:00Z],
+          repository_id: repository.id
+        })
+        |> Repo.insert!()
+
+      # Subscribe, unsubscribe, then broadcast
+      assert :ok = PubSub.subscribe_to_workflow_runs()
+      assert :ok = PubSub.unsubscribe_from_workflow_runs()
+      assert :ok = PubSub.broadcast_workflow_run_update(workflow_run, "completed")
+
+      # Should not receive message
+      refute_receive %{type: :workflow_run_updated}, 100
+    end
+  end
+
+  describe "workflow job broadcasting" do
+    test "broadcast_workflow_job_update/2 broadcasts correct message format" do
+      repository =
+        %Repository{}
+        |> Repository.changeset(%{
+          github_id: 123_456,
+          owner: "test",
+          name: "repo"
+        })
+        |> Repo.insert!()
+
+      workflow_run =
+        %WorkflowRun{}
+        |> WorkflowRun.changeset(%{
+          github_id: 1_234_567_890,
+          name: "CI",
+          status: "completed",
+          workflow_id: 161_335,
+          head_branch: "main",
+          head_sha: "abc123",
+          run_number: 42,
+          started_at: ~U[2021-01-01 00:00:00Z],
+          repository_id: repository.id
+        })
+        |> Repo.insert!()
+
+      workflow_job =
+        %WorkflowJob{}
+        |> WorkflowJob.changeset(%{
+          github_id: 4_407_365_498,
+          name: "test",
+          status: "completed",
+          conclusion: "success",
+          runner_name: "GitHub Actions 1",
+          runner_group_name: "GitHub Actions",
+          started_at: ~U[2021-01-01 00:00:00Z],
+          completed_at: ~U[2021-01-01 00:01:00Z],
+          workflow_run_id: workflow_run.id
+        })
+        |> Repo.insert!()
+
+      # Subscribe to workflow jobs
+      assert :ok = PubSub.subscribe_to_workflow_jobs()
+
+      # Broadcast update
+      assert :ok = PubSub.broadcast_workflow_job_update(workflow_job, "completed")
+
+      # Verify message received
+      assert_receive %{
+        type: :workflow_job_updated,
+        event_type: "completed",
+        workflow_job: ^workflow_job
+      }
+    end
+
+    test "subscribe_to_workflow_jobs/0 allows receiving messages" do
+      repository =
+        %Repository{}
+        |> Repository.changeset(%{
+          github_id: 123_456,
+          owner: "test",
+          name: "repo"
+        })
+        |> Repo.insert!()
+
+      workflow_run =
+        %WorkflowRun{}
+        |> WorkflowRun.changeset(%{
+          github_id: 1_234_567_890,
+          name: "CI",
+          status: "completed",
+          workflow_id: 161_335,
+          head_branch: "main",
+          head_sha: "abc123",
+          run_number: 42,
+          started_at: ~U[2021-01-01 00:00:00Z],
+          repository_id: repository.id
+        })
+        |> Repo.insert!()
+
+      workflow_job =
+        %WorkflowJob{}
+        |> WorkflowJob.changeset(%{
+          github_id: 4_407_365_498,
+          name: "test",
+          status: "in_progress",
+          runner_name: "GitHub Actions 1",
+          runner_group_name: "GitHub Actions",
+          started_at: ~U[2021-01-01 00:00:00Z],
+          workflow_run_id: workflow_run.id
+        })
+        |> Repo.insert!()
+
+      # Subscribe and broadcast
+      assert :ok = PubSub.subscribe_to_workflow_jobs()
+      assert :ok = PubSub.broadcast_workflow_job_update(workflow_job, "in_progress")
+
+      # Should receive message
+      assert_receive %{type: :workflow_job_updated, event_type: "in_progress"}
+    end
+
+    test "unsubscribe_from_workflow_jobs/0 stops receiving messages" do
+      repository =
+        %Repository{}
+        |> Repository.changeset(%{
+          github_id: 123_456,
+          owner: "test",
+          name: "repo"
+        })
+        |> Repo.insert!()
+
+      workflow_run =
+        %WorkflowRun{}
+        |> WorkflowRun.changeset(%{
+          github_id: 1_234_567_890,
+          name: "CI",
+          status: "completed",
+          workflow_id: 161_335,
+          head_branch: "main",
+          head_sha: "abc123",
+          run_number: 42,
+          started_at: ~U[2021-01-01 00:00:00Z],
+          repository_id: repository.id
+        })
+        |> Repo.insert!()
+
+      workflow_job =
+        %WorkflowJob{}
+        |> WorkflowJob.changeset(%{
+          github_id: 4_407_365_498,
+          name: "test",
+          status: "completed",
+          conclusion: "success",
+          runner_name: "GitHub Actions 1",
+          runner_group_name: "GitHub Actions",
+          started_at: ~U[2021-01-01 00:00:00Z],
+          completed_at: ~U[2021-01-01 00:01:00Z],
+          workflow_run_id: workflow_run.id
+        })
+        |> Repo.insert!()
+
+      # Subscribe, unsubscribe, then broadcast
+      assert :ok = PubSub.subscribe_to_workflow_jobs()
+      assert :ok = PubSub.unsubscribe_from_workflow_jobs()
+      assert :ok = PubSub.broadcast_workflow_job_update(workflow_job, "completed")
+
+      # Should not receive message
+      refute_receive %{type: :workflow_job_updated}, 100
+    end
+  end
+
+  describe "integration with webhook handler" do
+    test "workflow run webhook processing broadcasts message" do
+      # Subscribe before operation
+      assert :ok = PubSub.subscribe_to_workflow_runs()
+
+      # Process workflow run through webhook handler
+      payload = %{
+        "action" => "completed",
+        "workflow_run" => %{
+          "id" => 1_234_567_890,
+          "name" => "CI",
+          "status" => "completed",
+          "conclusion" => "success",
+          "workflow_id" => 161_335,
+          "head_branch" => "main",
+          "head_sha" => "009b8a3a9ccbb128af87f9b1c0f4c62e8a304f6d",
+          "run_number" => 42,
+          "run_started_at" => "2021-01-01T00:00:00Z",
+          "updated_at" => "2021-01-01T00:01:00Z"
+        },
+        "repository" => %{
+          "id" => 35_129_377,
+          "name" => "docs",
+          "full_name" => "github/docs",
+          "owner" => %{
+            "login" => "github",
+            "id" => 9_919_815
+          }
+        }
+      }
+
+      assert :ok = CiRunners.Github.WebhookHandler.handle_workflow_run(payload)
+
+      # Should receive broadcast message
+      assert_receive %{
+        type: :workflow_run_updated,
+        event_type: "completed"
+      }
+    end
+
+    test "workflow job webhook processing broadcasts message" do
+      # Subscribe before operation
+      assert :ok = PubSub.subscribe_to_workflow_jobs()
+
+      # Process workflow job through webhook handler
+      payload = %{
+        "action" => "completed",
+        "workflow_job" => %{
+          "id" => 4_407_365_498,
+          "run_id" => 1_234_567_890,
+          "workflow_name" => "CI",
+          "head_branch" => "main",
+          "head_sha" => "009b8a3a9ccbb128af87f9b1c0f4c62e8a304f6d",
+          "name" => "test",
+          "status" => "completed",
+          "conclusion" => "success",
+          "started_at" => "2021-01-01T00:00:00Z",
+          "completed_at" => "2021-01-01T00:01:00Z",
+          "runner_name" => "GitHub Actions 1",
+          "runner_group_name" => "GitHub Actions"
+        },
+        "repository" => %{
+          "id" => 35_129_377,
+          "name" => "docs",
+          "full_name" => "github/docs",
+          "owner" => %{
+            "login" => "github",
+            "id" => 9_919_815
+          }
+        }
+      }
+
+      assert :ok = CiRunners.Github.WebhookHandler.handle_workflow_job(payload)
+
+      # Should receive broadcast message
+      assert_receive %{
+        type: :workflow_job_updated,
+        event_type: "completed"
+      }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implement Phoenix PubSub broadcasting for workflow run and job events
- Add CiRunners.PubSub helper module with standardized message formats
- Enable real-time dashboard updates through automatic broadcasting from webhook handler
- Complete Task 5 (PubSub Integration) from project roadmap

## Key Changes
- **CiRunners.PubSub module**: Helper functions for broadcasting and subscription management
- **Webhook handler integration**: Automatic PubSub broadcasting after database updates
- **Standardized message formats**: Consistent structure for workflow_run_updated and workflow_job_updated events
- **Comprehensive test coverage**: 8 tests including integration tests with webhook handler

## Test Plan
- [x] Unit tests for PubSub broadcasting and subscription functions
- [x] Integration tests with webhook handler
- [x] Message format validation
- [x] Subscribe/unsubscribe functionality verification
- [x] All tests passing with `mix test`

🤖 Generated with [Claude Code](https://claude.ai/code)